### PR TITLE
Correct chain up for do_startup method

### DIFF
--- a/engine/main.py
+++ b/engine/main.py
@@ -84,7 +84,7 @@ class IMApplication(Adw.Application):
         LOG_MSG.info("startup")
 
         # Is it the right way to chain up?
-        Gio.Application.do_startup(self)
+        Adw.Application.do_startup(self)
 
     def do_command_line(self, args):
         already_running=args.get_is_remote()


### PR DESCRIPTION
- Call the do_startup method for its immediate parent, Adw.Application instead of Gio.Application