### PR TITLE
Replace AdwPreferencesPage with GtkBox for categorypage

### DIFF
--- a/engine/sttconfigdialog.ui
+++ b/engine/sttconfigdialog.ui
@@ -171,8 +171,8 @@
 
   </template>
 
-  <object class="AdwPreferencesPage" id="categorypage">
-    <property name="name">Command</property>
+  <object class="GtkBox" id="categorypage">
+    <property name="orientation">vertical</property>
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>


### PR DESCRIPTION
- Fix blank Text Formatting page when clicking shortcut categories

- AdwPreferencesPage only accepts AdwPreferencesGroup as direct children. categorypage used a GtkBox as its direct child, which violated this constraint and caused Adwaita to silently drop the child widget resulting in a blank page whenever
a text formatting shortcut category (Commands, Case, Punctuation, etc.)
was activated.

```
(ibus-setup-stt:14376): Adwaita-CRITICAL **: Trying to add GtkBox as a
child to an AdwPreferencePage, but only AdwPreferenceGroup is allowed
```