### PR TITLE
Fix model unloading when switching/stopping 'Speech To Text' input source

### DIFF
--- a/engine/main.py
+++ b/engine/main.py
@@ -27,11 +27,9 @@ import gi
 
 gi.require_version('Gst', '1.0')
 gi.require_version('IBus', '1.0')
-gi.require_version('Adw', '1')
 
 from gi.repository import IBus
 from gi.repository import GLib
-from gi.repository import Adw
 from gi.repository import Gio
 from gi.repository import GObject
 from gi.repository import Gst
@@ -42,7 +40,7 @@ from sttgstfactory import stt_gst_factory_default
 
 LOG_MSG=logging.getLogger()
 
-class IMApplication(Adw.Application):
+class IMApplication(Gio.Application):
     __gtype_name__ = 'IMApplication'
 
     def __init__(self, **kwargs):
@@ -55,6 +53,9 @@ class IMApplication(Adw.Application):
         self.__bus=None
         self.__factory=None
         self.__component=None
+
+        self.__idle_timer=0
+        self.__input_sources_settings=None
 
     def do_handle_local_options(self, options):
         LOG_MSG.info("Local options parsing")
@@ -84,7 +85,7 @@ class IMApplication(Adw.Application):
         LOG_MSG.info("startup")
 
         # Is it the right way to chain up?
-        Adw.Application.do_startup(self)
+        Gio.Application.do_startup(self)
 
     def do_command_line(self, args):
         already_running=args.get_is_remote()
@@ -128,8 +129,18 @@ class IMApplication(Adw.Application):
         self.__bus = IBus.Bus()
         self.__bus.connect("disconnected", self.__bus_disconnected_cb)
 
-        self.__factory = STTEngineFactory(self.__bus)
+
+        self.__factory = STTEngineFactory(self.__bus,
+                                          activity_cb=self.__engine_activity_cb)
+
         self.__factory.add_engine("stt", GObject.type_from_name("STTEngine"))
+
+        schema_source=Gio.SettingsSchemaSource.get_default()
+        if schema_source is not None and \
+           schema_source.lookup("org.gnome.desktop.input-sources", True) is not None:
+            self.__input_sources_settings=Gio.Settings.new("org.gnome.desktop.input-sources")
+            self.__input_sources_settings.connect("changed::sources",
+                                                  self.__input_sources_changed_cb)
 
         if self.__exec_by_ibus:
             self.__bus.request_name("org.freedesktop.IBus.STT", 0)
@@ -138,12 +149,71 @@ class IMApplication(Adw.Application):
             self.__component = IBus.Component.new_from_file(xml_path)
             self.__bus.register_component (self.__component)
 
+        self.__engine_activity_cb(self.__factory.engine_count)
+
         # Start a loop
         self.hold()
 
     def __bus_disconnected_cb(self, bus):
         LOG_MSG.info("bus disconnect")
         self.release()
+
+    def __stt_in_input_sources(self):
+        if self.__input_sources_settings is None:
+            return None
+
+        sources=self.__input_sources_settings.get_value("sources").unpack()
+        return ("ibus", "stt") in sources
+
+    def __engine_activity_cb(self, engine_count):
+        if engine_count > 0:
+            if self.__idle_timer != 0:
+                LOG_MSG.debug("engine created, cancelling idle-exit timer")
+                GLib.source_remove(self.__idle_timer)
+                self.__idle_timer=0
+            return
+
+        if self.__stt_in_input_sources() is False:
+            self.__idle_exit_now()
+            return
+
+        if self.__idle_timer == 0:
+            LOG_MSG.info("no engine left alive, idle-exit in %is", 10)
+            self.__idle_timer=GLib.timeout_add_seconds(10, self.__idle_exit_cb)
+
+    def __input_sources_changed_cb(self, settings, key):
+        if self.__stt_in_input_sources() is not False:
+            return
+
+        LOG_MSG.info("STT removed from input sources, unloading model")
+        stt_gst_factory_default().drop_preload()
+
+        if self.__factory is not None and \
+           self.__factory.engine_count == 0:
+            self.__idle_exit_now()
+
+    def __idle_exit_now(self):
+        if self.__idle_timer != 0:
+            GLib.source_remove(self.__idle_timer)
+            self.__idle_timer=0
+        self.__idle_exit_cb()
+
+    def __idle_exit_cb(self):
+        self.__idle_timer=0
+        gst_factory=stt_gst_factory_default()
+        in_sources=self.__stt_in_input_sources()
+
+        if in_sources is False:
+            LOG_MSG.info("STT not among input sources, exiting")
+            gst_factory.drop_preload()
+            self.release()
+        elif gst_factory.has_preload == False:
+            LOG_MSG.info("idle with no preloaded engine, exiting")
+            self.release()
+        else:
+            LOG_MSG.info("staying alive to keep the preloaded engine warm")
+
+        return GLib.SOURCE_REMOVE
 
 if __name__ == "__main__":
     LOG_MSG=logging.getLogger()
@@ -163,7 +233,6 @@ if __name__ == "__main__":
     locale.textdomain('ibus-stt')
 
     Gst.init(sys.argv)
-    Adw.init()
 
     app = IMApplication(application_id=stt_utils_get_app_id(),
                         flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE|

--- a/engine/sttengine.py
+++ b/engine/sttengine.py
@@ -26,10 +26,8 @@ import gi
 
 gi.require_version('IBus', '1.0')
 gi.require_version('Pango', '1.0')
-gi.require_version('Gtk', '4.0')
 
 from gi.repository import IBus
-from gi.repository import Gtk, Adw
 from gi.repository import Gio
 
 from sttutils import *
@@ -364,6 +362,10 @@ class STTEngine(IBus.Engine):
         elif prop_name == 'configuration':
             subprocess.Popen([os.path.join(stt_utils_get_libexec(), "ibus-setup-stt")])
         elif prop_name == 'about':
+            gi.require_version('Gtk', '4.0')
+            gi.require_version('Adw', '1')
+            from gi.repository import Gtk, Adw
+            Adw.init()
             dialog = Adw.AboutWindow(application_name=_("IBus Speech To Text"),
                             title=_("About IBus Speech To Text"),
                             application_icon="user-available-symbolic",

--- a/engine/sttenginefactory.py
+++ b/engine/sttenginefactory.py
@@ -30,12 +30,18 @@ LOG_MSG=logging.getLogger()
 class STTEngineFactory(IBus.Factory):
     __gtype_name__ = 'STTEngineFactory'
 
-    def __init__(self, bus):
+    def __init__(self, bus, activity_cb=None):
         self._bus=bus
         self._current_engine=None
+        self._engine_count=0
+        self._activity_cb=activity_cb
         super().__init__(object_path=IBus.PATH_FACTORY,
                          connection=bus.get_connection())
         # Stop there, we create this object to control engine creation
+
+    @property
+    def engine_count(self):
+        return self._engine_count
 
     def do_create_engine(self, engine_name):
         LOG_MSG.debug("New engine requested %s", engine_name)
@@ -44,8 +50,20 @@ class STTEngineFactory(IBus.Factory):
 
         engine=STTEngine(self._bus, "/org/freedesktop/IBus/STT")
         self._current_engine=engine
-        LOG_MSG.debug("Creating new engine")
+
+        self._engine_count += 1
+        engine.connect("destroy", self.__engine_destroyed_cb)
+        LOG_MSG.debug("Creating new engine (%i alive)", self._engine_count)
+        if self._activity_cb is not None:
+            self._activity_cb(self._engine_count)
+
         return engine
+
+    def __engine_destroyed_cb(self, engine):
+        self._engine_count=max(0, self._engine_count - 1)
+        LOG_MSG.debug("Engine destroyed (%i alive)", self._engine_count)
+        if self._activity_cb is not None:
+            self._activity_cb(self._engine_count)
 
     def do_destroy(self):
         self._current_engine=None

--- a/engine/sttgstbase.py
+++ b/engine/sttgstbase.py
@@ -77,6 +77,12 @@ class STTGstBase (GObject.Object):
         self._pipeline.set_state(Gst.State.NULL)
         self._pipeline=None
 
+        try:
+            import ctypes
+            ctypes.CDLL("libc.so.6").malloc_trim(0)
+        except (OSError, AttributeError):
+            pass
+
         LOG_MSG.info("GstBase.destroy() called")
 
     def hold(self):

--- a/engine/sttgstfactory.py
+++ b/engine/sttgstfactory.py
@@ -24,11 +24,6 @@ from gi.repository import Gio
 
 from sttutils import *
 
-from sttgstvosk import STTGstVosk
-from sttgstwhisper import STTGstWhisper
-from sttgstonnxasr import STTGstOnnxAsr
-from sttgstmoonshine import STTGstMoonshine
-
 from sttbackenddeps import (stt_backend_display_name,
                             stt_backend_install_command,
                             stt_backend_is_available)
@@ -66,15 +61,19 @@ class STTGstFactory(GObject.GObject):
                 backend = "vosk"
             if backend == "whisper":
                 LOG_MSG.info("Using Whisper backend")
+                from sttgstwhisper import STTGstWhisper
                 engine=STTGstWhisper()
             elif backend == "onnxasr":
                 LOG_MSG.info("Using onnx-asr backend")
+                from sttgstonnxasr import STTGstOnnxAsr
                 engine=STTGstOnnxAsr()
             elif backend == "moonshine":
                 LOG_MSG.info("Using Moonshine backend")
+                from sttgstmoonshine import STTGstMoonshine
                 engine=STTGstMoonshine()
             else:
                 LOG_MSG.info("Using Vosk backend")
+                from sttgstvosk import STTGstVosk
                 engine=STTGstVosk()
             self._current_engine=weakref.ref(engine)
         else:
@@ -100,6 +99,18 @@ class STTGstFactory(GObject.GObject):
 
     def __preload_changed(self, settings, key):
         self.__update_preloaded_engine()
+
+    @property
+    def has_preload(self):
+        return self._preload is not None
+
+    def drop_preload(self):
+        if self._preload is None:
+            return
+
+        LOG_MSG.info("dropping preloaded engine")
+        self._preload.release()
+        self._preload=None
 
 _GLOBAL_FACTORY = None
 


### PR DESCRIPTION
Fixes issue #22 by releasing loaded speech models when switching or stopping the `Speech To Text` input source
This patch and allows: 

- Dropping the preloaded engine explicitly 

- Exit when idle and unload model when STT source is removed

- Import backend modules lazily in the gst factory and trim the heap after unloading a pipeline.